### PR TITLE
refactor: package itens units according to package itens units quantity

### DIFF
--- a/front/src/components/BoughtProducts/index.jsx
+++ b/front/src/components/BoughtProducts/index.jsx
@@ -63,7 +63,7 @@ const BoughtProducts = () => {
               <Heading fontSize='20px'>
                 Pacote {pos + 1}
               </Heading>
-              <Text pl='2' fontWeight='semibold' color='#9E9E9E'>(1 item, {produtos[pos]?.quantidade} unidades)</Text>
+              <Text pl='2' fontWeight='semibold' color='#9E9E9E'>(1 item, {produtos[pos]?.quantidade} {produtos[pos]?.quantidade === 1 ? "unidade" : "unidades"})</Text>
             </Box>
             <Stack spacing={'32px'} direction={['column', 'row']}>
               <Box>


### PR DESCRIPTION
Antes da alteração a palavra que acompanhava a número de unidades estava sempre no plural agora ficará no plural apenas se for mais de 1 unidade.

segue imagens:
antes da alteração: https://prnt.sc/9w3dnJFadbte

depois da alteração: https://prnt.sc/y3bK7ompuHtS

O pedido que está nas imagens é o de número 03107013